### PR TITLE
Handle recording-failure

### DIFF
--- a/bots/bot_controller/bot_controller.py
+++ b/bots/bot_controller/bot_controller.py
@@ -270,6 +270,16 @@ class BotController:
         if self.get_recording_file_location():
             logger.info("Telling file uploader to upload recording file...")
             logger.info("file_name: %s", self.get_recording_filename())
+
+            # Get the transcript ID from the recording filename
+            transcript_id = self.get_recording_filename().split(".")[0]
+
+            # Check if the file exists and is not empty
+            if os.path.getsize(self.get_recording_file_location()) == 0:
+                logger.info("Recording file is empty, not uploading")
+                transcript_api_service.could_not_record(transcript_id)
+                return
+
             file_uploader = FileUploader(
                 os.environ.get("AWS_RECORDING_STORAGE_BUCKET_NAME"),
                 self.get_recording_filename(),
@@ -279,7 +289,6 @@ class BotController:
             logger.info("File uploader finished uploading file")
 
             # After successful upload, call the Transcript API to transcribe the file
-            transcript_id = self.get_recording_filename().split(".")[0]
             logger.info("Transcript ID: %s", transcript_id)
             try:
                 logger.info("Sending transcription request...")

--- a/transcript_services/v1/api_service.py
+++ b/transcript_services/v1/api_service.py
@@ -20,7 +20,7 @@ def start_transcription(transcript_uuid):
         raise ValueError("API key is not set in environment variables.")
 
     # API endpoint
-    url = os.getenv("TRANSCRIPT_API_URL")
+    url = os.getenv("TRANSCRIPT_API_URL") + "/v1/record/done"
 
     if not url:
         raise ValueError("API URL is not set in environment variables.")
@@ -43,6 +43,42 @@ def start_transcription(transcript_uuid):
         print(f"Successfully started transcription for UUID: {transcript_uuid}")
     else:
         print(f"Error starting transcription: {response.status_code}")
+        print(f"Response: {response.text}")
+
+    return response
+
+
+def could_not_record(transcript_id):
+    # API credentials
+    api_key = os.getenv("TRANSCRIPT_API_KEY")
+
+    if not api_key:
+        raise ValueError("API key is not set in environment variables.")
+
+    # API endpoint
+    url = os.getenv("TRANSCRIPT_API_URL") + "/v1/record/failed"
+
+    if not url:
+        raise ValueError("API URL is not set in environment variables.")
+
+    # Request headers
+    headers = {
+        "x-api-key": api_key,
+    }
+
+    # Request parameters
+    params = {
+        "transcript_id": transcript_id
+    }
+
+    # Send POST request
+    response = requests.post(url, headers=headers, params=params)
+
+    # Check if request was successful
+    if response.status_code == 200:
+        print(f"Successfully informed of recording failure for UUID: {transcript_id}")
+    else:
+        print(f"Error informing of recording failure: {response.status_code}")
         print(f"Response: {response.text}")
 
     return response


### PR DESCRIPTION
When the recorder fails, we do not upload an empty file – as was previously the case – but instead update the transcript as "could-not-record".