### PR TITLE
Hasith/tra 451 status recorded should only be assigned if actually

### DIFF
--- a/bots/bot_controller/gstreamer_pipeline.py
+++ b/bots/bot_controller/gstreamer_pipeline.py
@@ -5,6 +5,7 @@ import logging
 import time
 
 from gi.repository import GLib, Gst
+
 from bots.utils import create_black_i420_frame, create_zero_pcm_audio
 
 # Set up the logging configuration

--- a/bots/bots_api_utils.py
+++ b/bots/bots_api_utils.py
@@ -5,7 +5,6 @@ import uuid
 from enum import Enum
 
 import redis
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.urls import reverse

--- a/bots/bots_api_views.py
+++ b/bots/bots_api_views.py
@@ -17,7 +17,8 @@ from rest_framework.pagination import CursorPagination
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from transcript_services.v1.api_service import started_recording, start_transcription, could_not_record
+from transcript_services.v1.api_service import could_not_record, start_transcription, started_recording
+
 from .authentication import ApiKeyAuthentication
 from .bots_api_utils import BotCreationSource, create_bot, create_bot_chat_message_request, create_bot_media_request_for_image, delete_bot, patch_bot, send_sync_command
 from .launch_bot_utils import launch_bot

--- a/bots/models.py
+++ b/bots/models.py
@@ -4,12 +4,12 @@ Data models for Projects, Calendars, Bots, and related entities.
 
 import hashlib
 import json
+import logging
 import math
 import os
 import random
 import secrets
 import string
-import logging
 
 from concurrency.exceptions import RecordModifiedError
 from concurrency.fields import IntegerVersionField

--- a/bots/models.py
+++ b/bots/models.py
@@ -1241,7 +1241,7 @@ class BotEventManager:
         if in_progress_recordings.count() > 1:
             raise ValidationError(f"Expected at most one in progress recording for bot {bot.object_id} in state {BotStates.state_to_api_code(new_state)}, but found {in_progress_recordings.count()}")
         for recording in in_progress_recordings:
-            RecordingManager.terminate_recording(recording)
+            RecordingManager.terminate_recording(recording, event_type=event_type)
         for failed_transcription_recording in bot.recordings.filter(transcription_state=RecordingTranscriptionStates.FAILED):
             # Collect all transcription errors
             if failed_transcription_recording.transcription_failure_data and failed_transcription_recording.transcription_failure_data.get("failure_reasons"):
@@ -1589,10 +1589,14 @@ class RecordingManager:
     # If the transcription failed, then mark it as failed
     # If the transcription succeeded, then mark it as succeeded
     @classmethod
-    def terminate_recording(cls, recording: Recording):
+    def terminate_recording(cls, recording: Recording, event_type: int = None):
         if recording.state == RecordingStates.IN_PROGRESS or recording.state == RecordingStates.PAUSED:
+            # If the bot encountered a fatal error, mark the recording as failed regardless of file existence.
+            # A file may exist from partial writes/buffering, but the recording was interrupted abnormally.
+            if event_type == BotEventTypes.FATAL_ERROR:
+                RecordingManager.set_recording_failed(recording)
             # If we don't have a recording file AND we intended to generate one, then it failed.
-            if recording.file or recording.bot.recording_type() == RecordingTypes.NO_RECORDING:
+            elif recording.file or recording.bot.recording_type() == RecordingTypes.NO_RECORDING:
                 RecordingManager.set_recording_complete(recording)
             else:
                 RecordingManager.set_recording_failed(recording)

--- a/bots/projects_views.py
+++ b/bots/projects_views.py
@@ -749,7 +749,7 @@ class CreateCheckoutSessionView(LoginRequiredMixin, ProjectUrlContextMixin, View
 
 class CreateBotView(LoginRequiredMixin, ProjectUrlContextMixin, View):
     def post(self, request, object_id):
-        logger.debug(f"Creating bot...")
+        logger.debug("Creating bot...")
         try:
             logger.debug("Getting project for user...")
             project = get_project_for_user(user=request.user, project_object_id=object_id)

--- a/bots/serializers.py
+++ b/bots/serializers.py
@@ -4,8 +4,6 @@ import logging
 import os
 from dataclasses import asdict
 
-from django.conf import settings
-
 logger = logging.getLogger(__name__)
 
 import jsonschema

--- a/bots/storage/infomaniak_storage.py
+++ b/bots/storage/infomaniak_storage.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 
 from django.core.files.base import ContentFile
 from django.core.files.storage import Storage

--- a/bots/storage/infomaniak_swift_utils.py
+++ b/bots/storage/infomaniak_swift_utils.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 
 from swiftclient import client
 from swiftclient.exceptions import ClientException

--- a/bots/tasks/process_utterance_task.py
+++ b/bots/tasks/process_utterance_task.py
@@ -1,6 +1,5 @@
 import logging
 
-import requests
 from celery import shared_task
 
 logger = logging.getLogger(__name__)

--- a/bots/tests/test_bot_data_deletion.py
+++ b/bots/tests/test_bot_data_deletion.py
@@ -1,5 +1,5 @@
 import uuid
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 from django.core.files.base import ContentFile
 from django.test import TransactionTestCase

--- a/bots/tests/test_recording_termination.py
+++ b/bots/tests/test_recording_termination.py
@@ -1,0 +1,311 @@
+"""
+Unit tests for RecordingManager.terminate_recording() method.
+Tests the fix for properly handling recording status when a pod dies (FATAL_ERROR).
+"""
+from unittest.mock import PropertyMock, patch
+
+from django.core.files.base import ContentFile
+from django.test import TransactionTestCase
+from django.test.utils import override_settings
+
+from bots.models import (
+    Bot,
+    BotEventTypes,
+    BotStates,
+    Organization,
+    Participant,
+    Project,
+    Recording,
+    RecordingManager,
+    RecordingStates,
+    RecordingTranscriptionStates,
+    RecordingTypes,
+    Utterance,
+)
+
+
+def mock_file_field_delete_sets_name_to_none(instance, save=True):
+    """Mock FieldFile.delete to simulate file deletion"""
+    instance.name = None
+    if save:
+        instance.instance.save()
+
+
+def mock_file_field_save(instance, name, content, save=True):
+    """Mock FieldFile.save to simulate file save"""
+    instance.name = name
+    if save:
+        instance.instance.save()
+
+
+class TestRecordingTermination(TransactionTestCase):
+    """Test cases for recording termination logic when a pod dies"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.settings_override = override_settings(SWIFT_CONTAINER_MEETS="test-bucket")
+        cls.settings_override.enable()
+
+    def setUp(self):
+        """Set up test fixtures"""
+        # Setup patches for file operations
+        self.delete_patch = patch("django.db.models.fields.files.FieldFile.delete", autospec=True)
+        self.save_patch = patch("django.db.models.fields.files.FieldFile.save", autospec=True)
+
+        # Start patches
+        self.delete_mock = self.delete_patch.start()
+        self.save_mock = self.save_patch.start()
+
+        # Set side effects
+        self.delete_mock.side_effect = mock_file_field_delete_sets_name_to_none
+        self.save_mock.side_effect = mock_file_field_save
+
+        # Create test organization
+        self.organization = Organization.objects.create(name="Test Org")
+
+        # Create test project
+        self.project = Project.objects.create(organization=self.organization, name="Test Project")
+
+        # Create a test bot
+        self.bot = Bot.objects.create(
+            project=self.project,
+            name="Test Bot",
+            meeting_url="https://test.com/meeting",
+            state=BotStates.JOINED_RECORDING,
+        )
+
+        # Create a test participant
+        self.participant = Participant.objects.create(
+            bot=self.bot, uuid="test-participant", full_name="Test Participant"
+        )
+
+    def tearDown(self):
+        """Clean up patches"""
+        self.save_patch.stop()
+        self.delete_patch.stop()
+
+    def test_terminate_recording_with_fatal_error_marks_recording_as_failed(self):
+        """
+        Test that when a FATAL_ERROR event is provided, the recording is marked as FAILED
+        even if a file exists (partial write from crashed pod).
+        """
+        # Create a recording in IN_PROGRESS state with a file
+        recording = Recording.objects.create(
+            bot=self.bot,
+            recording_type=RecordingTypes.AUDIO_AND_VIDEO,
+            transcription_type=1,
+            state=RecordingStates.IN_PROGRESS,
+        )
+
+        # Add a file to simulate partial write from crashed pod
+        recording.file.save("partial_recording.mp4", ContentFile(b"partial content"))
+        recording.refresh_from_db()
+
+        # Verify file exists
+        self.assertTrue(bool(recording.file))
+
+        # Terminate recording with FATAL_ERROR event type
+        RecordingManager.terminate_recording(recording, event_type=BotEventTypes.FATAL_ERROR)
+
+        # Verify recording is marked as FAILED (not COMPLETE)
+        recording.refresh_from_db()
+        self.assertEqual(recording.state, RecordingStates.FAILED)
+
+    def test_terminate_recording_without_event_type_uses_file_existence_logic(self):
+        """
+        Test that without event_type parameter, the original logic applies:
+        if file exists, mark as COMPLETE; if no file, mark as FAILED.
+        """
+        # Create a recording in IN_PROGRESS state with a file
+        recording = Recording.objects.create(
+            bot=self.bot,
+            recording_type=RecordingTypes.AUDIO_AND_VIDEO,
+            transcription_type=1,
+            state=RecordingStates.IN_PROGRESS,
+        )
+
+        # Add a file
+        recording.file.save("complete_recording.mp4", ContentFile(b"complete content"))
+        recording.refresh_from_db()
+
+        # Terminate recording without event_type (original behavior)
+        RecordingManager.terminate_recording(recording)
+
+        # Verify recording is marked as COMPLETE (because file exists)
+        recording.refresh_from_db()
+        self.assertEqual(recording.state, RecordingStates.COMPLETE)
+
+    def test_terminate_recording_without_file_marks_as_failed(self):
+        """
+        Test that recording without a file is marked as FAILED
+        (unless recording type is NO_RECORDING).
+        """
+        # Create a recording in IN_PROGRESS state without a file
+        recording = Recording.objects.create(
+            bot=self.bot,
+            recording_type=RecordingTypes.AUDIO_AND_VIDEO,
+            transcription_type=1,
+            state=RecordingStates.IN_PROGRESS,
+        )
+
+        # Don't add a file
+
+        # Terminate recording
+        RecordingManager.terminate_recording(recording)
+
+        # Verify recording is marked as FAILED (no file and not NO_RECORDING type)
+        recording.refresh_from_db()
+        self.assertEqual(recording.state, RecordingStates.FAILED)
+
+    def test_terminate_recording_no_recording_type_marked_complete(self):
+        """
+        Test that NO_RECORDING type recordings are marked as COMPLETE
+        even without a file.
+        """
+        # Configure bot to have NO_RECORDING format
+        self.bot.settings = {
+            "recording_settings": {
+                "format": "none"  # RecordingFormats.NONE
+            }
+        }
+        self.bot.save()
+
+        # Create a recording with NO_RECORDING type
+        recording = Recording.objects.create(
+            bot=self.bot,
+            recording_type=RecordingTypes.NO_RECORDING,
+            transcription_type=1,
+            state=RecordingStates.IN_PROGRESS,
+        )
+
+        # Don't add a file
+
+        # Terminate recording
+        RecordingManager.terminate_recording(recording)
+
+        # Verify recording is marked as COMPLETE (NO_RECORDING type doesn't need a file)
+        recording.refresh_from_db()
+        self.assertEqual(recording.state, RecordingStates.COMPLETE)
+
+    def test_terminate_recording_paused_state_with_fatal_error(self):
+        """
+        Test that PAUSED recordings are also handled correctly with FATAL_ERROR.
+        """
+        # Create a paused recording with a file
+        recording = Recording.objects.create(
+            bot=self.bot,
+            recording_type=RecordingTypes.AUDIO_AND_VIDEO,
+            transcription_type=1,
+            state=RecordingStates.PAUSED,
+        )
+
+        # Add a file
+        recording.file.save("paused_recording.mp4", ContentFile(b"paused content"))
+        recording.refresh_from_db()
+
+        # Terminate recording with FATAL_ERROR
+        RecordingManager.terminate_recording(recording, event_type=BotEventTypes.FATAL_ERROR)
+
+        # Verify recording is marked as FAILED
+        recording.refresh_from_db()
+        self.assertEqual(recording.state, RecordingStates.FAILED)
+
+    def test_terminate_recording_handles_transcription_state(self):
+        """
+        Test that transcription state is properly handled during termination.
+        """
+        # Create a recording with IN_PROGRESS transcription
+        recording = Recording.objects.create(
+            bot=self.bot,
+            recording_type=RecordingTypes.AUDIO_AND_VIDEO,
+            transcription_type=1,
+            state=RecordingStates.IN_PROGRESS,
+            transcription_state=RecordingTranscriptionStates.IN_PROGRESS,
+        )
+
+        # Add a file
+        recording.file.save("recording_with_transcription.mp4", ContentFile(b"content"))
+        recording.refresh_from_db()
+
+        # Create an utterance that is still in progress (no transcription yet)
+        Utterance.objects.create(
+            recording=recording,
+            participant=self.participant,
+            audio_blob=b"audio data",
+            timestamp_ms=1000,
+            duration_ms=500,
+        )
+
+        # Terminate recording with FATAL_ERROR
+        RecordingManager.terminate_recording(recording, event_type=BotEventTypes.FATAL_ERROR)
+
+        # Verify recording state is FAILED
+        recording.refresh_from_db()
+        self.assertEqual(recording.state, RecordingStates.FAILED)
+
+        # Verify transcription state is FAILED (has in-progress utterances)
+        self.assertEqual(recording.transcription_state, RecordingTranscriptionStates.FAILED)
+
+    def test_terminate_recording_fatal_error_vs_other_event_types(self):
+        """
+        Test that only FATAL_ERROR event type triggers the special handling.
+        Other event types should use the normal file-existence logic.
+        """
+        # Create two recordings with files
+        recording_fatal = Recording.objects.create(
+            bot=self.bot,
+            recording_type=RecordingTypes.AUDIO_AND_VIDEO,
+            transcription_type=1,
+            state=RecordingStates.IN_PROGRESS,
+        )
+        recording_fatal.file.save("recording_fatal.mp4", ContentFile(b"content"))
+        recording_fatal.refresh_from_db()
+
+        recording_normal = Recording.objects.create(
+            bot=self.bot,
+            recording_type=RecordingTypes.AUDIO_AND_VIDEO,
+            transcription_type=1,
+            state=RecordingStates.IN_PROGRESS,
+        )
+        recording_normal.file.save("recording_normal.mp4", ContentFile(b"content"))
+        recording_normal.refresh_from_db()
+
+        # Terminate with FATAL_ERROR
+        RecordingManager.terminate_recording(recording_fatal, event_type=BotEventTypes.FATAL_ERROR)
+
+        # Terminate with MEETING_ENDED (normal event)
+        RecordingManager.terminate_recording(recording_normal, event_type=BotEventTypes.MEETING_ENDED)
+
+        # Verify FATAL_ERROR -> FAILED
+        recording_fatal.refresh_from_db()
+        self.assertEqual(recording_fatal.state, RecordingStates.FAILED)
+
+        # Verify MEETING_ENDED -> COMPLETE (because file exists)
+        recording_normal.refresh_from_db()
+        self.assertEqual(recording_normal.state, RecordingStates.COMPLETE)
+
+    def test_terminate_recording_preserves_completed_at_timestamp(self):
+        """
+        Test that completed_at timestamp is set when recording is completed.
+        """
+        recording = Recording.objects.create(
+            bot=self.bot,
+            recording_type=RecordingTypes.AUDIO_AND_VIDEO,
+            transcription_type=1,
+            state=RecordingStates.IN_PROGRESS,
+        )
+        recording.file.save("recording.mp4", ContentFile(b"content"))
+        recording.refresh_from_db()
+
+        # Verify completed_at is None before termination
+        self.assertIsNone(recording.completed_at)
+
+        # Terminate recording normally (should mark as COMPLETE)
+        RecordingManager.terminate_recording(recording)
+
+        recording.refresh_from_db()
+
+        # Verify completed_at is set
+        self.assertIsNotNone(recording.completed_at)
+        self.assertEqual(recording.state, RecordingStates.COMPLETE)

--- a/bots/tests/test_recording_termination.py
+++ b/bots/tests/test_recording_termination.py
@@ -2,7 +2,7 @@
 Unit tests for RecordingManager.terminate_recording() method.
 Tests the fix for properly handling recording status when a pod dies (FATAL_ERROR).
 """
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 from django.core.files.base import ContentFile
 from django.test import TransactionTestCase

--- a/bots/utils.py
+++ b/bots/utils.py
@@ -10,6 +10,7 @@ from .models import (
     TranscriptionProviders,
 )
 
+
 def pcm_to_mp3(
     pcm_data: bytes,
     sample_rate: int = 32000,

--- a/transcript_services/v1/api_service.py
+++ b/transcript_services/v1/api_service.py
@@ -1,7 +1,7 @@
+import logging
 import os
 
 import requests
-import logging
 
 # Setup logging
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
# Basic checks

- [x] My code builds clean without any errors or warnings
- [x] I ran `ruff check` and `ruff format .`
- [x] I rebased my branch on main

# What's changed?

- When a bot pod crashes during recording (FATAL_ERROR), the recording was incorrectly marked as COMPLETE if any partial file existed from partial writes/buffering.

- Improve RecordingManager.terminate_recording() to distinguish between normal termination and abnormal pod failure:
- Added parameter to the termination logic
- FATAL_ERROR handling: When a pod crashes (FATAL_ERROR event), recording is marked as FAILED regardless of file existence
